### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ejs": "^3.1.9",
     "express": "^4.18.2",
     "fuse.js": "^7.1.0",
-    "mongoose": "^7.5.0"
+    "mongoose": "^7.5.0",
+    "express-rate-limit": "^8.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,8 +4,19 @@ const Fuse = require('fuse.js');
 const Item = require('./models/Item');
 require('dotenv').config();
 
+// Add express-rate-limit for basic DoS protection
+const rateLimit = require('express-rate-limit');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+// Set up a basic rate limiter: 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.use(limiter);
 
 app.set('view engine', 'ejs');
 


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/search-engine/security/code-scanning/1](https://github.com/glowedjelly/search-engine/security/code-scanning/1)

To fix this issue, we should add a rate limiting middleware (such as [`express-rate-limit`](https://www.npmjs.com/package/express-rate-limit)) to the Express app. The best practice is to apply rate limiting globally with `app.use()`, or specifically to the vulnerable route. The most consistent approach (matching the CodeQL example) is to import `express-rate-limit`, configure a limiter (for example, 100 requests per 15 minutes per IP), and use `app.use(limiter)` to protect all routes, including the database-backed route in question. 

One change is needed to `server.js`:
- Import `express-rate-limit` and define a limiter instance.
- Apply the limiter before defining the route(s) and before any route handling.
- No change to existing app functionality or logic (i.e. do not change route definitions).
- Only add an import and limiter setup near the other middleware (`app.set`, before any route definitions).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
