### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/search-engine/security/code-scanning/5](https://github.com/glowedjelly/search-engine/security/code-scanning/5)

The best way to fix the problem is to explicitly add a `permissions:` block to the workflow file with the least required privileges. For an npm publish workflow, the default minimal starting point is `contents: read`, which allows just read access to repo contents. If the workflow or jobs need additional write privileges (e.g., to create releases or update PRs), those should be added case by case; here, `contents: read` suffices for most package publish workflows.

The update should be made at the root level of the workflow file (right after the `name:` field and before `on:`), so all jobs inherit these permissions unless overridden. No new imports or code definitions are required, just a configuration addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
